### PR TITLE
FIX : replace the hardcoded profession list by the application proprty 'deactivation.excluded.profession.codes'.

### DIFF
--- a/pscload/src/main/java/fr/ans/psc/pscload/component/Runner.java
+++ b/pscload/src/main/java/fr/ans/psc/pscload/component/Runner.java
@@ -45,6 +45,7 @@ import fr.ans.psc.pscload.state.exception.ExtractTriggeringException;
 import fr.ans.psc.pscload.state.exception.LoadProcessException;
 import fr.ans.psc.pscload.state.exception.SerFileGenerationException;
 import fr.ans.psc.pscload.state.exception.UploadException;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -141,8 +142,11 @@ public class Runner {
                 customMetrics.setStageMetric(Stage.READY_TO_EXTRACT);
                 // Step 2 : Extract
                 process.nextStep();
-                process.setState(new ReadyToComputeDiff(customMetrics, apiBaseUrl));
+                
+                final List<String> excludedProfessionList = List.of(Objects.requireNonNullElse(excludedProfessions, new String[]{}));
+                process.setState(new ReadyToComputeDiff(excludedProfessionList, customMetrics, apiBaseUrl));
                 customMetrics.setStageMetric(Stage.READY_TO_COMPUTE);
+                
                 // Step 4 : Load maps and compute diff
                 process.nextStep();
                 // check if differences exist

--- a/pscload/src/main/java/fr/ans/psc/pscload/controller/TestingController.java
+++ b/pscload/src/main/java/fr/ans/psc/pscload/controller/TestingController.java
@@ -38,6 +38,7 @@ import fr.ans.psc.pscload.state.ProcessState;
 import fr.ans.psc.pscload.state.ReadyToComputeDiff;
 import fr.ans.psc.pscload.state.ReadyToExtract;
 import fr.ans.psc.pscload.state.Submitted;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -151,7 +152,7 @@ public class TestingController {
 			} else if (States.READY_TO_EXTRACT.classname.equals(state)) {
 				processState = new ReadyToExtract();
 			} else if (States.READY_TO_COMPUTE_DIFF.classname.equals(state)) {
-				processState = new ReadyToComputeDiff(customMetrics, apiBaseUrl);
+        processState = new ReadyToComputeDiff(List.of("60"), customMetrics, apiBaseUrl);
 			} else if (States.DIFF_COMPUTED.classname.equals(state)){
 				processState = new DiffComputed(customMetrics);
 			} else {

--- a/pscload/src/test/java/fr/ans/psc/pscload/component/ProcessRegistryTest.java
+++ b/pscload/src/test/java/fr/ans/psc/pscload/component/ProcessRegistryTest.java
@@ -65,6 +65,7 @@ import fr.ans.psc.pscload.state.UploadInterrupted;
 import fr.ans.psc.pscload.state.UploadingChanges;
 import fr.ans.psc.pscload.utils.FileUtils;
 import fr.ans.psc.pscload.model.operations.OperationType;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -276,7 +277,7 @@ class ProcessRegistryTest {
 		if (mapser.exists()) {
 			mapser.delete();
 		}
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile = FileUtils.copyFileToWorkspace(fileName1);
 		p.setExtractedFilename(extractFile.getPath());
 		httpMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -290,7 +291,7 @@ class ProcessRegistryTest {
 		p.getState().setProcess(p);
 		p.nextStep();
 
-		LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile2 = FileUtils.copyFileToWorkspace(fileName2);
 		p2.setExtractedFilename(extractFile2.getPath());
 		p2.getState().setProcess(p2);

--- a/pscload/src/test/java/fr/ans/psc/pscload/state/ChangesAppliedTest.java
+++ b/pscload/src/test/java/fr/ans/psc/pscload/state/ChangesAppliedTest.java
@@ -48,6 +48,7 @@ import fr.ans.psc.pscload.model.operations.OperationMap;
 import fr.ans.psc.pscload.service.EmailService;
 import fr.ans.psc.pscload.utils.FileUtils;
 import fr.ans.psc.pscload.model.operations.OperationType;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -133,7 +134,7 @@ public class ChangesAppliedTest {
             mapser.delete();
         }
         //Day 1 : Generate old ser file
-        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
         File extractFile1 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120512.txt");
         p.setExtractedFilename(extractFile1.getPath());
         httpMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -155,7 +156,7 @@ public class ChangesAppliedTest {
         httpMockServer.stubFor(delete("/v2/ps/810107592585")
                 .willReturn(aResponse().withStatus(410)));
         // Day 2 : Compute diff
-        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
         registry.register(Integer.toString(registry.nextId()), p2);
         File extractFile2 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120515.txt");
         p2.setExtractedFilename(extractFile2.getPath());

--- a/pscload/src/test/java/fr/ans/psc/pscload/state/DiffComputedStateTest.java
+++ b/pscload/src/test/java/fr/ans/psc/pscload/state/DiffComputedStateTest.java
@@ -39,6 +39,7 @@ import fr.ans.psc.pscload.metrics.CustomMetrics.SizeMetric;
 import fr.ans.psc.pscload.model.LoadProcess;
 import fr.ans.psc.pscload.service.EmailService;
 import fr.ans.psc.pscload.utils.FileUtils;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -111,7 +112,7 @@ public class DiffComputedStateTest {
         if (mapser.exists()) {
             mapser.delete();
         }
-        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
         File extractFile = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120512.txt");
         p.setExtractedFilename(extractFile.getPath());
         httpMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -136,7 +137,7 @@ public class DiffComputedStateTest {
         p.getState().setProcess(p);
         p.nextStep();
 
-        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
         File extractFile2 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120515.txt");
         p2.setExtractedFilename(extractFile2.getPath());
         p2.getState().setProcess(p2);

--- a/pscload/src/test/java/fr/ans/psc/pscload/state/ReadyToComputeDiffTest.java
+++ b/pscload/src/test/java/fr/ans/psc/pscload/state/ReadyToComputeDiffTest.java
@@ -52,6 +52,7 @@ import fr.ans.psc.pscload.model.operations.OperationMap;
 import fr.ans.psc.pscload.service.EmailService;
 import fr.ans.psc.pscload.utils.FileUtils;
 import fr.ans.psc.pscload.model.operations.OperationType;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -130,7 +131,7 @@ class ReadyToComputeDiffTest {
 //		if (mapser.exists()) {
 //			mapser.delete();
 //		}
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120512.txt");
 		p.setExtractedFilename(extractFile.getPath());
 
@@ -160,7 +161,7 @@ class ReadyToComputeDiffTest {
 //		if (mapser.exists()) {
 //			mapser.delete();
 //		}
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120512.txt");
 		p.setExtractedFilename(extractFile.getPath());
 		httpMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -174,7 +175,7 @@ class ReadyToComputeDiffTest {
 		p.getState().setProcess(p);
 		p.nextStep();
 
-		LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile2 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120515.txt");
 		p2.setExtractedFilename(extractFile2.getPath());
 		p2.getState().setProcess(p2);
@@ -210,7 +211,7 @@ class ReadyToComputeDiffTest {
 //		if (mapser.exists()) {
 //			mapser.delete();
 //		}
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File extractFile = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112140852.txt");
 		p.setExtractedFilename(extractFile.getPath());
 		httpMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -225,7 +226,7 @@ class ReadyToComputeDiffTest {
 	@Disabled
 	@DisplayName("check order impact on hashCode and equals methods")
 	public void checkDifferentOrderForPs() throws IOException {
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File file1 = FileUtils.copyFileToWorkspace("2WorkSituationsOrder1");
 		ReadyToComputeDiff state = (ReadyToComputeDiff) p.getState();
 		Map<String, Professionnel> order1Map = state.loadMapsFromFile(file1);
@@ -246,7 +247,7 @@ class ReadyToComputeDiffTest {
 	@Disabled
 	@DisplayName("check that the order of first names is handled correctly")
 	public void checkCorrectFirstNameOrder() throws IOException {
-		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpMockServer.baseUrl()));
+		LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpMockServer.baseUrl()));
 		File file1 = FileUtils.copyFileToWorkspace("FirstNameOrder");
 		ReadyToComputeDiff state = (ReadyToComputeDiff) p.getState();
 		Map<String, Professionnel> nameOrderMap = state.loadMapsFromFile(file1);

--- a/pscload/src/test/java/fr/ans/psc/pscload/state/UploadingStateTest.java
+++ b/pscload/src/test/java/fr/ans/psc/pscload/state/UploadingStateTest.java
@@ -50,6 +50,7 @@ import fr.ans.psc.pscload.model.operations.OperationMap;
 import fr.ans.psc.pscload.service.EmailService;
 import fr.ans.psc.pscload.utils.FileUtils;
 import fr.ans.psc.pscload.model.operations.OperationType;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -125,7 +126,7 @@ public class UploadingStateTest {
         httpApiMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
 
         //Day 1 : Generate old ser file
-        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpApiMockServer.baseUrl()));
+        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpApiMockServer.baseUrl()));
         File extractFile1 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120513.txt");
         p.setExtractedFilename(extractFile1.getPath());
         p.getState().setProcess(p);
@@ -145,7 +146,7 @@ public class UploadingStateTest {
                 .willReturn(aResponse().withStatus(200)));
         httpApiMockServer.stubFor(any(urlMatching("/generate-extract")).willReturn(aResponse().withStatus(200)));
         // Day 2 : Compute diff (1 delete)
-        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpApiMockServer.baseUrl()));
+        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpApiMockServer.baseUrl()));
         registry.register(Integer.toString(registry.nextId()), p2);
         File extractFile2 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120514.txt");
         p2.setExtractedFilename(extractFile2.getPath());
@@ -190,7 +191,7 @@ public class UploadingStateTest {
             mapser.delete();
         }
         //Day 1 : Generate old ser file
-        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpApiMockServer.baseUrl()));
+        LoadProcess p = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpApiMockServer.baseUrl()));
         File extractFile1 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120513.txt");
         p.setExtractedFilename(extractFile1.getPath());
         httpApiMockServer.stubFor(get(urlPathEqualTo("/v2/ps")).withQueryParam("page", equalTo("0"))
@@ -209,7 +210,7 @@ public class UploadingStateTest {
                 .willReturn(aResponse().withStatus(410)));
         httpApiMockServer.stubFor(any(urlMatching("/generate-extract")).willReturn(aResponse().withStatus(200)));
         // Day 2 : Compute diff (1 delete)
-        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(customMetrics, httpApiMockServer.baseUrl()));
+        LoadProcess p2 = new LoadProcess(new ReadyToComputeDiff(List.of("60"),customMetrics, httpApiMockServer.baseUrl()));
         registry.register(Integer.toString(registry.nextId()), p2);
         File extractFile2 = FileUtils.copyFileToWorkspace("Extraction_ProSanteConnect_Personne_activite_202112120514.txt");
         p2.setExtractedFilename(extractFile2.getPath());


### PR DESCRIPTION
Closes #25 
Emergency FIX for preprodcution amar tests. A separate PR will be issued for production release.