### PR TITLE
Add instructions so that people update distribution history when they release psc-rass-loader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Component to load RASS data in psc db
 
 ## Developement
 
+### Distribution history
+
+This ecosystem uses many independant components, some of which live an independant life in distinct repositories.
+For each release of `psc-ps-api`, [the psc-compoents' distribution  history](https://github.com/ansforge/psc-components/blob/main/DISTRIBUTION.md) 
+file will need to be updated with the new version, so that we can keep track of compatible component versions, 
+and go back to a previous working distribution if need be.
+
 ### Release procedure
 
 Whenever a version is ready for release, run the following commands on the `main` branch (or on the maintenance branch if we're about to issue a production FIX). This should run on any shell, be it `bash`, `cmd` or if needed `gitbash`.


### PR DESCRIPTION
Closes #31 